### PR TITLE
With Django 1.7 django_pdb needs to come BEFORE apps it overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,12 +19,17 @@ Install using pip::
 
     pip install django-pdb
 
-Add to your settings.py
+Add it to your settings.py.
+
+For Django before 1.7 it needs to be added AFTER any apps that override the
+`runserver` or `test` commands (includes south and django.contrib.staticfiles).
+
+For Django after 1.7 it needs to be added BEFORE them.
 
 .. code:: python
 
-    # Make sure to add django_pdb AFTER any apps that override the 'runserver'
-    # or 'test' commands (includes south and django.contrib.staticfiles)
+    # Order is important and depends on your Django version.
+    # With Django 1.7+ put it towards the beginning, otherwise towards the end.
     INSTALLED_APPS = (
         ...
         'django_pdb',


### PR DESCRIPTION
To override "runserver" from 'django.contrib.staticfiles', it needs to
come BEFORE it, because Django uses the list of app configs in reversed
order.

From django/core/management/__init__.py(76)get_commands():

    for app_config in reversed(list(apps.get_app_configs())):
        path = os.path.join(app_config.path, 'management')
        commands.update({name: app_config.name for name in find_commands(path)})