### PR TITLE
Adapt to Django 1.8 option_list changes

### DIFF
--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -1,4 +1,5 @@
 # Django settings for testproject project.
+from django import VERSION
 
 
 def ABSOLUTE_PATH(relative_path):
@@ -12,7 +13,11 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 TESTING = False
 
-TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+
+if VERSION >= (1, 8):
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+else:
+    TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),


### PR DESCRIPTION
Django 1.8 depercates option_list as optparse is replaced by argparse.
Adding options to option_list does not work in Django 1.8.

For details, please see:
https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#accepting-optional-arguments
https://github.com/django/django/commit/856863860352aa1f0288e6c9168a0e423c4f5184