### PR TITLE
Remove deprecation warning while importing importlib.

### DIFF
--- a/django_pdb/management/__init__.py
+++ b/django_pdb/management/__init__.py
@@ -1,6 +1,10 @@
+import django
 from django.core import management
 from django.core.management import find_commands
-from django.utils.importlib import import_module
+if django.VERSION >= (1, 8):
+    from importlib import import_module
+else:
+    from django.utils.importlib import import_module
 
 from ..compat import load_management_modules
 


### PR DESCRIPTION
More information about this deprecation is available here https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib