### PR TITLE
Django's copy of unittest is replaced with python's

### DIFF
--- a/django_pdb/testrunners.py
+++ b/django_pdb/testrunners.py
@@ -2,7 +2,7 @@ import pdb
 
 from django.test.utils import get_runner
 
-from django.utils import unittest
+import unittest
 from django_pdb.utils import has_ipdb
 
 


### PR DESCRIPTION
django.utils.unittest is deprecated and will be removed in Django 1.9, thus the change